### PR TITLE
improve: enrich package.json metadata for npm discoverability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [commit-and-tag-version](https://github.com/absolute-version/commit-and-tag-version) for commit guidelines.
 
+## [14.0.2](https://github.com/brmorillo/util/compare/v14.0.1...v14.0.2) (2026-06-17)
+
 ## [14.0.1](https://github.com/brmorillo/util/compare/v12.0.0...v14.0.1) (2026-06-17)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brmorillo/utils",
-  "version": "14.0.1",
+  "version": "14.0.2",
   "description": "Production-ready utility library for JS/TS — 27 modules behind one type-safe API: arrays, objects, strings, crypto, JWT, UUID, sorting, queues, caches, HTTP, logging, storage and more.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,17 @@
 {
   "name": "@brmorillo/utils",
   "version": "14.0.1",
-  "description": "Utility library for JavaScript/TypeScript projects",
+  "description": "Production-ready utility library for JS/TS — 27 modules behind one type-safe API: arrays, objects, strings, crypto, JWT, UUID, sorting, queues, caches, HTTP, logging, storage and more.",
   "main": "dist/index.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "files": [
     "dist/**/*",
     "README.md",
@@ -44,7 +52,21 @@
     "utils",
     "utilities",
     "helpers",
-    "typescript"
+    "typescript",
+    "javascript",
+    "nodejs",
+    "type-safe",
+    "cryptography",
+    "jwt",
+    "uuid",
+    "sorting",
+    "queue",
+    "cache",
+    "http",
+    "logging",
+    "storage",
+    "esm",
+    "commonjs"
   ],
   "author": "Bruno Morillo",
   "license": "LGPL-3.0-only",


### PR DESCRIPTION
- description: replace generic text with a concise feature summary
- exports: add conditional exports map (require/import/types) so bundlers resolve CJS vs ESM automatically without guessing
- module: add "module" field pointing to ESM build for legacy bundlers
- keywords: expand from 4 to 18 terms covering the actual modules (crypto, jwt, uuid, sorting, queue, cache, http, logging, storage, esm, commonjs)